### PR TITLE
ad_sthlp - implement sthlp conversion to not rely on markdoc

### DIFF
--- a/src/ado/ad_sthlp.ado
+++ b/src/ado/ad_sthlp.ado
@@ -113,14 +113,14 @@ cap program drop   ad_sthlp
 
         * Title 1 heading #
         else if (substr(trim(`"`line'"'),1,2) == "# ") {
-          local title = trim(subinstr("`line'","# ","",1))
-          file write `st_fh' "{title:`title'}" _n
+          local title1 = trim(subinstr("`line'","# ","",1))
+          file write `st_fh' "{title:`title1'}" _n
         }
 
         * Title 2 heading ##
         else if (substr(trim(`"`line'"'),1,3) == "## ") {
-          local title = trim(subinstr("`line'","## ","",1))
-          file write `st_fh' "{dlgtab:`title'}" _n
+          local title2 = trim(subinstr("`line'","## ","",1))
+          file write `st_fh' "{dlgtab:`title2'}" _n
         }
 
         * Table | --- | --- |
@@ -138,7 +138,7 @@ cap program drop   ad_sthlp
           }
           * End of table - write the table and reset table locals
           else if (`table' == 1) {
-            write_table, handle(`st_fh') tbl_str(`"`tbl_str'"') section("`title'")
+            write_table, handle(`st_fh') tbl_str(`"`tbl_str'"') section("`title1'")
             local table = 0
             local tbl_str = ""
           }
@@ -150,7 +150,9 @@ cap program drop   ad_sthlp
         else {
 
           if (`paragraph' == 0 & `codeblock' == 0 ) {
-            file write `st_fh' "{pstd}"
+            if inlist("`title1'", "Title", "Syntax") local ptype "{phang}"
+            else local ptype "{pstd}"
+            file write `st_fh' "`ptype'"
             local paragraph = !`paragraph'
           }
 

--- a/src/ado/ad_sthlp.ado
+++ b/src/ado/ad_sthlp.ado
@@ -367,7 +367,7 @@ cap program drop   	write_table
       forvalues row = 1/`r_exp_count' {
          file write `handle' "`row_`row''" _n
       }
-      file write `handle' "{synoptline}" _n
+      file write `handle' "{synoptline}" _n _n
 
     }
     else {

--- a/src/ado/ad_sthlp.ado
+++ b/src/ado/ad_sthlp.ado
@@ -360,7 +360,8 @@ cap program drop   	parse_table_row
         if missing("``++tok_i''") local more_cols 0
         else if ("``tok_i''" != "|") {
             return local c`++col_i' = trim("``tok_i''")
-            return local c`col_i'_l = strlen(trim("``tok_i''"))
+            display_len, str(`=trim("``tok_i''")')
+            return local c`col_i'_l = `r(dlen)'
         }
     }
     return local c_count `col_i'
@@ -453,6 +454,24 @@ cap program drop   	parse_hyperlinks
  else return local line `"`line'"'
 
 end
+
+cap program drop 	display_len
+	program define	display_len, rclass
+
+	syntax, [str(string)]
+
+    if missing("`str'") return local dlen 0
+    else {
+      local str_len = strlen("`str'")
+      local tag_len = 0
+      foreach tag in inp bf ul it {
+        local str : subinstr local str "{`tag':" "", all count(local count)
+        local tag_len = `tag_len' + (`count' * strlen("{`tag':}"))
+      }
+      return local dlen = (`str_len' - `tag_len')
+    }
+end
+
 
 * Splits a file name into its name and its extension
 cap program drop 	split_file_extentsion

--- a/src/ado/templates/ad-cmd-command.md
+++ b/src/ado/templates/ad-cmd-command.md
@@ -11,21 +11,17 @@ __ADCOMMANDNAME__ , __**opt**ion1__(_string_)
 | __**opt**ion1__(_string_)   | Short description of option1  |
 
 # Description
-
 <!-- Longer description of the intended use of the command and best practices related to the usage. -->
 
 # Options
-
 <!-- Longer description (paragraph length) of all options, their intended use case and best practices related to them. -->
 
 __**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
 
 # Examples
-
 <!-- A couple of examples to help the user get started and a short explanation of each of them. -->
 
 # Feedback, bug reports and contributions
-
 <!-- A couple of examples to help the user get started and a short explanation of each of them. -->
 
 # Authors

--- a/src/ado/templates/ad-cmd-command.md
+++ b/src/ado/templates/ad-cmd-command.md
@@ -12,21 +12,21 @@ __ADCOMMANDNAME__ , __**opt**ion1__(_string_)
 
 # Description
 
-<!--- Longer description of the intended use of the command and best practices related to the usage. -->
+<!-- Longer description of the intended use of the command and best practices related to the usage. -->
 
 # Options
 
-<!--- Longer description (paragraph length) of all options, their intended use case and best practices related to them. -->
+<!-- Longer description (paragraph length) of all options, their intended use case and best practices related to them. -->
 
 __**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
 
 # Examples
 
-<!--- A couple of examples to help the user get started and a short explanation of each of them. -->
+<!-- A couple of examples to help the user get started and a short explanation of each of them. -->
 
 # Feedback, bug reports and contributions
 
-<!--- A couple of examples to help the user get started and a short explanation of each of them. -->
+<!-- A couple of examples to help the user get started and a short explanation of each of them. -->
 
 # Authors
 

--- a/src/ado/templates/ad-cmd-command.md
+++ b/src/ado/templates/ad-cmd-command.md
@@ -4,11 +4,11 @@ __ADCOMMANDNAME__ - This command is used for short description.
 
 # Syntax
 
-__ADCOMMANDNAME__ , option1(_string_)
+__ADCOMMANDNAME__ , __**opt**ion1__(_string_)
 
 | _options_ | Description |
 |-----------|-------------|
-| option1(_string_)   | Short description of option1  |
+| __**opt**ion1__(_string_)   | Short description of option1  |
 
 # Description
 
@@ -18,7 +18,7 @@ __ADCOMMANDNAME__ , option1(_string_)
 
 <!--- Longer description (paragraph length) of all options, their intended use case and best practices related to them. -->
 
-option1(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
+__**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
 
 # Examples
 

--- a/src/mdhlp/ad_command.md
+++ b/src/mdhlp/ad_command.md
@@ -1,22 +1,22 @@
 # Title
 
-__ad_command__ - Creates or removes commands in the adodown workflow.
+__ad_command__ - Creates or removes commands in the `adodown` workflow.
 
 # Syntax
 
-__ad_command__ _subcommand_ _commandname_ , **adf**older(_string_) **pkg**name(_string_)
+__ad_command__ _subcommand_ _commandname_ , __**adf**older__(_string_) __**pkg**name__(_string_)
 
 where _subcommand_ is either `create` or `remove` and _commandname_ is the name of the new command to create or the existing command to remove.
 
 | _options_ | Description |
 |------------------|-------------|
-| **adf**older(_string_) | Location where package folder already exists |
-| **pkg**name(_string_) | Name of package that exists in the location adfolder() points to. |
+| __**adf**older__(_string_) | Location where package folder already exists |
+| __**pkg**name__(_string_) | Name of package that exists in the location `adfolder()` points to. |
 
 
 # Description
 
-This command is only intended to be used in package folders set up in the adodown workflow using the command `ad_setup`.
+This command is only intended to be used in package folders set up in the `adodown` workflow using the command `ad_setup`.
 
 This command creates new commands in the package or removes existing commands from it. When creating a command, a template for the ado-file is created in the ado folder, a template for the mdhlp-file is created in the mdhlp folder,
 and the ado-file and the sthlp file is addended to the pkg-file in that package folder.
@@ -29,13 +29,13 @@ _subcommand_ as specified in `ad_command <subcommand> <commandname>` can either 
 
 _commandname_ as specified in `ad_command <subcommand> <commandname>` is the name of the command to be created or removed. If a command is created then an error is thrown if the name is already used by an existing command, and an error will be thrown when removing a command if the name is not used by any existing commands.
 
-**adf**older(_string_) is used to indicate the location of where the adodown-styled package folder already exist.
+__**adf**older__(_string_) is used to indicate the location of where the adodown-styled package folder already exist.
 
-**pkg**name(_string_) is the name of the package expected to be found in the adfolder().
+__**pkg**name__(_string_) is the name of the package expected to be found in the `adfolder()`.
 
 # Examples
 
-__Example 1__
+## Example 1
 
 This example assumes that there is already a adodown-styled package folder at the location the local `myfolder` is pointing to.
 
@@ -51,7 +51,7 @@ ad_command create mycmd, adf("`myfolder'") pkg("`pkg'")
 ```
 
 
-__Example 2__
+## Example 2
 
 This example includes the steps for how to create the adodown-styled package folder in the location the local `myfolder` is pointing to.
 
@@ -77,7 +77,7 @@ ad_command create mycmd, adf("`myfolder'") pkg("`pkg'")
 
 # Feedback, bug reports and contributions
 
-Please use the [issues feature](https://github.com/lsms-worldbank/adodown/issues) on the GitHub repository for the adodown package to communicate any feedback, report bugs, or to make feature requests.
+Please use the [issues feature](https://github.com/lsms-worldbank/adodown/issues) on the GitHub repository for the `adodown` package to communicate any feedback, report bugs, or to make feature requests.
 
 # Authors
 

--- a/src/mdhlp/ad_setup.md
+++ b/src/mdhlp/ad_setup.md
@@ -4,18 +4,18 @@ __ad_setup__ - Sets up the initial package folder in the `adodown` workflow.
 
 # Syntax
 
-__ad_setup__ , **adf**older(_string_) [ **n**ame(_string_) **d**escription(_string_) **a**uthor(_string_) **c**ontact(_string_) **u**rl(_string_) **auto**prompt **git**hub
+__ad_setup__ , __**adf**older__(_string_) [ __**n**ame__(_string_) __**d**escription__(_string_) __**a**uthor__(_string_) __**c**ontact__(_string_) __**u**rl__(_string_) __**auto**prompt__ __**git**hub__ ]
 
 | _options_ | Description |
 |--------------------|-------------|
-| **adf**older(_string_)    | Location where package folder will be created |
-| **n**ame(_string_)        | Name of package |
-| **d**escription(_string_) | Description of package |
-| **a**uthor(_string_)      | Author or authors |
-| **c**ontact(_string_)     | Contact information |
-| **u**rl(_string_)         | URl (for example to repo hosting the package) |
-| **auto**prompt              | Suppress the prompt for missing non-required input  |
-| **git**hub                | Add GitHub template files without prompting  |
+| __**adf**older__(_string_)    | Location where package folder will be created |
+| __**n**ame__(_string_)        | Name of package |
+| __**d**escription__(_string_) | Description of package |
+| __**a**uthor__(_string_)      | Author or authors |
+| __**c**ontact__(_string_)     | Contact information |
+| __**u**rl__(_string_)         | URl (for example to repo hosting the package) |
+| __**auto**prompt__              | Suppress the prompt for missing non-required input  |
+| __**git**hub__                | Add GitHub template files without prompting  |
 
 # Description
 
@@ -25,21 +25,21 @@ This workflow makes it easier to create Stata command and packages both ready fo
 
 # Options
 
-**adf**older(_string_) is used to indicate the location where package folder will be created. This folder can for example be a newly created GitHub repository cloned to the local computer.
+__**adf**older__(_string_) is used to indicate the location where package folder will be created. This folder can for example be a newly created GitHub repository cloned to the local computer.
 
-**n**ame(_string_) specifies the name of the package that will be created. This is the name that would then be used in `ssc install <name>` or `net install <name>`. A command with the same name will be created and added to the package. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+__**n**ame__(_string_) specifies the name of the package that will be created. This is the name that would then be used in `ssc install <name>` or `net install <name>`. A command with the same name will be created and added to the package. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
 
-**d**escription(_string_) specifies the description of the package. This is the description paragraph that will displayed when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+__**d**escription__(_string_) specifies the description of the package. This is the description paragraph that will displayed when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
 
-**a**uthor(_string_) specifies the name of the author or authors of this package. This information will be included when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+__**a**uthor__(_string_) specifies the name of the author or authors of this package. This information will be included when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
 
-**c**ontact(_string_) specifies the contact information where a users of this package can ask for support. This information will be included when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+__**c**ontact__(_string_) specifies the contact information where a users of this package can ask for support. This information will be included when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
 
-**u**rl(_string_) specifies a website for where this code is hosted. This should not be where the web-documentation generated in the adodown is hosted, but where the source code is hosted. The web-documentation will include a link pointing to the URL. If using GitHub, then the intended URL should be on this format: https://github.com/lsms-worldbank/adodown. This information will be included when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+__**u**rl__(_string_) specifies a website for where this code is hosted. This should not be where the web-documentation generated in the adodown is hosted, but where the source code is hosted. The web-documentation will include a link pointing to the URL. If using GitHub, then the intended URL should be on this format: https://github.com/lsms-worldbank/adodown. This information will be included when using `ssc describe <name>` or `net describe <name>`. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
 
-**auto**prompt suppresses the prompt for missing non-required input, such as package description or author. If this options is used, the command will assume that GitHub templates should not be used. When this option is used, the command will still prompt the user for the package name unless that is provided in `name()` as that information is required.
+__**auto**prompt__ suppresses the prompt for missing non-required input, such as package description or author. If this options is used, the command will assume that GitHub templates should not be used. When this option is used, the command will still prompt the user for the package name unless that is provided in `name()` as that information is required.
 
-**git**hub makes the command add template files useful if the package is stored in a GitHub repository. The two files that are added are a .gitignore file and a GitHub Actions template. The .gitignore is tailored to adodown styled packages such that only required files are pushed to the repository. This template may be modified if preferred or needed. The Github Actions template includes instructions for an automated workflow to generate web based documentation. Read more about this workflow and how to enable it in your repository here. TODO: Add link to vignette when live.
+__**git**hub__ makes the command add template files useful if the package is stored in a GitHub repository. The two files that are added are a .gitignore file and a GitHub Actions template. The .gitignore is tailored to adodown styled packages such that only required files are pushed to the repository. This template may be modified if preferred or needed. The Github Actions template includes instructions for an automated workflow to generate web based documentation. Read more about this workflow and how to enable it in your repository here. TODO: Add link to vignette when live.
 
 # Examples
 

--- a/src/mdhlp/ad_sthlp.md
+++ b/src/mdhlp/ad_sthlp.md
@@ -1,25 +1,29 @@
 # Title
 
-__ad_sthlp__ - Renders sthlp-files from mdhlp-files in the adodown workflow.
+__ad_sthlp__ - Renders sthlp-files from mdhlp-files in the `adodown` workflow.
 
 # Syntax
 
-__ad_sthlp__ , **adf**older(_string_)
+__ad_sthlp__ , __**adf**older__(_string_)
 
 | _options_ | Description |
 |------------------|-------------|
-| **adf**older(_string_) | Location where package folder already exists |
+| __**adf**older__(_string_) | Location where package folder already exists |
 
 
 # Description
 
-This command renders Stata helpfiles in the `.sthlp` format written in the mdhlp-files written in markdown. The sthlp-files are then intended to be included instead of the mdhlp-files when distributing the command using either either `ssc install` or `net install`.
+This command renders Stata helpfiles in the `.sthlp` format
+written in the mdhlp-files written in markdown.
+The sthlp-files are then intended to be included instead
+of the mdhlp-files when distributing the command using
+either `ssc install` or `net install`.
 
-In the adodown workflow the mdhlp-files are expected to be stored in a folder `mdhlp` in the folder that **adf**older(_string_) points to, and the sthlp-files are expted to be written to a folder `sthlp` in the same location. If the package folder was set up using `ad_setup` and the commands were added to the package folder using `ad_command`, then this is already the case.
+In the `adodown` workflow the mdhlp-files are expected to be stored in a folder `mdhlp` in the folder that __**adf**older__(_string_) points to, and the sthlp-files are expected to be written to a folder `sthlp` in the same location. If the package folder was set up using `ad_setup` and the commands were added to the package folder using `ad_command`, then this is already the case.
 
 # Options
 
-**adf**older(_string_) is used to indicate the location of where the adodown-styled package folder already exist.
+__**adf**older__(_string_) is used to indicate the location of where the adodown-styled package folder already exist.
 
 # Examples
 
@@ -65,9 +69,9 @@ ad_sthlp, adf("`myfolder'")
 
 # Feedback, bug reports and contributions
 
-Please use the [issues feature](https://github.com/lsms-worldbank/adodown/issues) on the GitHub repository for the adodown package to communicate any feedback, report bugs, or to make feature requests.
+Please use the [issues feature](https://github.com/lsms-worldbank/adodown/issues) on the GitHub repository for the `adodown` package to communicate any feedback, report bugs, or to make feature requests.
 
 # Authors
 
-* Author: John Doe
-* Support: jdoe@worldbank.org
+Author: John Doe
+Support: jdoe@worldbank.org

--- a/src/mdhlp/ad_sthlp.md
+++ b/src/mdhlp/ad_sthlp.md
@@ -23,7 +23,7 @@ In the adodown workflow the mdhlp-files are expected to be stored in a folder `m
 
 # Examples
 
-__Example 1__
+## Example 1
 
 This example assumes that there is already a adodown-styled package folder at the location the local `myfolder` is pointing to, and that some commands have already been created. Any mdhlp-files in the `mdhlp` folder in the folder `myfolder` is pointing to will be rendered to Stata helpfile format and saved in the `sthlp` folder.
 
@@ -35,7 +35,7 @@ local myfolder "path/to/folder"
 ad_sthlp, adf("`myfolder'")
 ```
 
-__Example 2__
+## Example 2
 
 This example includes the steps for how to create the adodown-styled package folder in the location the local `myfolder` is pointing to, creating some commands and then render the template mdhlp-files to Stata helpfiles.
 

--- a/src/sthlp/ad_command.sthlp
+++ b/src/sthlp/ad_command.sthlp
@@ -1,103 +1,101 @@
 {smcl}
+{* 01 Jan 1960}{...}
+{hline}
+{pstd}help file for {hi:ad_command}{p_end}
+{hline}
+
 {title:Title}
 
-{p 4 4 2}
-{bf:ad_command} - Creates or removes commands in the adodown workflow.
+{phang}{bf:ad_command} - Creates or removes commands in the {inp:adodown} workflow.
+{p_end}
 
 {title:Syntax}
 
-{p 4 4 2}
-{bf:ad_command} {it:subcommand} {it:commandname} , {ul:adf}older({it:string}) {ul:pkg}name({it:string})
+{phang}{bf:ad_command} {it:subcommand} {it:commandname} , {bf:{ul:adf}older}({it:string}) {bf:{ul:pkg}name}({it:string})
+{p_end}
 
-{p 4 4 2}
-where {it:subcommand} is either {c 96}create{c 96} or {c 96}remove{c 96} and {it:commandname} is the name of the new command to create or the existing command to remove.
+{phang}where {it:subcommand} is either {inp:create} or {inp:remove} and {it:commandname} is the name of the new command to create or the existing command to remove.
+{p_end}
 
-{col 5}{it:options}{col 23}Description
-{space 4}{hline 31}
-{col 5}{ul:adf}older({it:string}){col 23}Location where package folder already exists
-{col 5}{ul:pkg}name({it:string}){col 23}Name of package that exists in the location adfolder() points to.
-{space 4}{hline 31}
+{synoptset 16}{...}
+{synopthdr:options}
+{synoptline}
+{synopt: {bf:{ul:adf}older}({it:string})}Location where package folder already exists{p_end}
+{synopt: {bf:{ul:pkg}name}({it:string})}Name of package that exists in the location {inp:adfolder()} points to.{p_end}
+{synoptline}
 
 {title:Description}
 
-{p 4 4 2}
-This command is only intended to be used in package folders set up in the adodown workflow using the command {c 96}ad_setup{c 96}.
+{pstd}This command is only intended to be used in package folders set up in the {inp:adodown} workflow using the command {inp:ad_setup}.
+{p_end}
 
-{p 4 4 2}
-This command creates new commands in the package or removes existing commands from it. When creating a command, a template for the ado-file is created in the ado folder, a template for the mdhlp-file is created in the mdhlp folder,
+{pstd}This command creates new commands in the package or removes existing commands from it. When creating a command, a template for the ado-file is created in the ado folder, a template for the mdhlp-file is created in the mdhlp folder,
 and the ado-file and the sthlp file is addended to the pkg-file in that package folder.
+{p_end}
 
-{p 4 4 2}
-Note that the using {c 96}net install{c 96} will not work immediately after creating a command with this file as the pkg-file points to the sthlp-file that is not yet rendered. Use the command {c 96}ad_sthlp{c 96} to render that command.
+{pstd}Note that the using {inp:net install} will not work immediately after creating a command with this file as the pkg-file points to the sthlp-file that is not yet rendered. Use the command {inp:ad_sthlp} to render that command.
+{p_end}
 
 {title:Options}
 
-{p 4 4 2}
-{it:subcommand} as specified in {c 96}ad_command <subcommand> <commandname>{c 96} can either be {c 96}create{c 96} or {c 96}remove{c 96}. {c 96}create{c 96} is used when creating a new command and {c 96}remove{c 96} when removing and existing command.
+{pstd}{it:subcommand} as specified in {inp:ad_command <subcommand> <commandname>} can either be {inp:create} or {inp:remove}. {inp:create} is used when creating a new command and {inp:remove} when removing and existing command.
+{p_end}
 
-{p 4 4 2}
-{it:commandname} as specified in {c 96}ad_command <subcommand> <commandname>{c 96} is the name of the command to be created or removed. If a command is created then an error is thrown if the name is already used by an existing command, and an error will be thrown when removing a command if the name is not used by any existing commands.
+{pstd}{it:commandname} as specified in {inp:ad_command <subcommand> <commandname>} is the name of the command to be created or removed. If a command is created then an error is thrown if the name is already used by an existing command, and an error will be thrown when removing a command if the name is not used by any existing commands.
+{p_end}
 
-{p 4 4 2}
-{ul:adf}older({it:string}) is used to indicate the location of where the adodown-styled package folder already exist.
+{pstd}{bf:{ul:adf}older}({it:string}) is used to indicate the location of where the adodown-styled package folder already exist.
+{p_end}
 
-{p 4 4 2}
-{ul:pkg}name({it:string}) is the name of the package expected to be found in the adfolder().
+{pstd}{bf:{ul:pkg}name}({it:string}) is the name of the package expected to be found in the {inp:adfolder()}.
+{p_end}
 
 {title:Examples}
 
-{p 4 4 2}
-{bf:Example 1}
+{dlgtab:Example 1}
 
-{p 4 4 2}
-This example assumes that there is already a adodown-styled package folder at the location the local {c 96}myfolder{c 96} is pointing to.
+{pstd}This example assumes that there is already a adodown-styled package folder at the location the local {inp:myfolder} is pointing to.
+{p_end}
 
-{c 96}{c 96}{c 96} 
-{break}    * point a local to the folder where the package will be created
-local myfolder "path/to/folder"
+{input}{space 8}* point a local to the folder where the package will be created
+{space 8}local myfolder "path/to/folder"
 
-{break}    * Package meta info
-local pkg "my_package"
+{space 8}* Package meta info
+{space 8}local pkg "my_package"
 
-{break}    * Add command mycmd to the package folder
-ad_command create mycmd, adf("{c 96}myfolder{c 39}") pkg("{c 96}pkg{c 39}")
-{c 96}{c 96}{c 96} 
+{space 8}* Add command mycmd to the package folder
+{space 8}ad_command create mycmd, adf("") pkg("")
+{text}
+{dlgtab:Example 2}
 
+{pstd}This example includes the steps for how to create the adodown-styled package folder in the location the local {inp:myfolder} is pointing to.
+{p_end}
 
-{p 4 4 2}
-{bf:Example 2}
+{input}{space 8}* point a local to the folder where the package will be created
+{space 8}local myfolder "path/to/folder"
 
-{p 4 4 2}
-This example includes the steps for how to create the adodown-styled package folder in the location the local {c 96}myfolder{c 96} is pointing to.
+{space 8}* Package meta info
+{space 8}local pkg "my_package"
+{space 8}local aut "John Doe"
+{space 8}local des "This packages does amazing thing A, B and C."
+{space 8}local url "https://github.com/lsms-worldbank/adodown"
+{space 8}local con "jdoe@worldbank.org"
 
-{c 96}{c 96}{c 96} 
-{break}    * point a local to the folder where the package will be created
-local myfolder "path/to/folder"
+{space 8}* Set up adodown-styled package folder
+{space 8}ad_setup, adfolder("") autoconfirm    ///
+{space 8}     name("") author("") desc("") ///
+{space 8}     url("") contact("")
 
-{break}    * Package meta info
-local pkg "my_package"
-local aut "John Doe"
-local des "This packages does amazing thing A, B and C."
-local url "https://github.com/lsms-worldbank/adodown"
-local con "jdoe@worldbank.org"
-
-{break}    * Set up adodown-styled package folder
-ad_setup, adfolder("{c 96}myfolder{c 39}") autoconfirm    ///
-     name("`pkg'") author("`aut'") desc("`des'") ///
-     url("`url'") contact("`con'")
-
-{break}    * Add command mycmd to the package folder
-ad_command create mycmd, adf("{c 96}myfolder{c 39}") pkg("{c 96}pkg{c 39}")
-{c 96}{c 96}{c 96} 
-
+{space 8}* Add command mycmd to the package folder
+{space 8}ad_command create mycmd, adf("") pkg("")
+{text}
 {title:Feedback, bug reports and contributions}
 
-{p 4 4 2}
-Please use the  {browse "https://github.com/lsms-worldbank/adodown/issues":issues feature} on the GitHub repository for the adodown package to communicate any feedback, report bugs, or to make feature requests.
+{pstd}Please use the {browse "https://github.com/lsms-worldbank/adodown/issues":issues feature} on the GitHub repository for the {inp:adodown} package to communicate any feedback, report bugs, or to make feature requests.
+{p_end}
 
 {title:Authors}
 
-{break}    * Author: John Doe
-{break}    * Support: jdoe@worldbank.org
-
-
+{pstd}* Author: John Doe
+* Support: jdoe@worldbank.org
+{p_end}

--- a/src/sthlp/ad_setup.sthlp
+++ b/src/sthlp/ad_setup.sthlp
@@ -1,83 +1,93 @@
 {smcl}
+{* 01 Jan 1960}{...}
+{hline}
+{pstd}help file for {hi:ad_setup}{p_end}
+{hline}
+
 {title:Title}
 
-{p 4 4 2}
-{bf:ad_setup} - Sets up the initial package folder in the adodown workflow.
+{phang}{bf:ad_setup} - Sets up the initial package folder in the {inp:adodown} workflow.
+{p_end}
 
 {title:Syntax}
 
-{p 4 4 2}
-{bf:ad_setup} , {ul:adf}older({it:string}) [ {ul:n}ame({it:string}) {ul:d}escription({it:string}) {ul:a}uthor({it:string}) {ul:c}ontact({it:string}) {ul:u}rl({it:string}) {ul:autocon}firm
+{phang}{bf:ad_setup} , {bf:{ul:adf}older}({it:string}) [ {bf:{ul:n}ame}({it:string}) {bf:{ul:d}escription}({it:string}) {bf:{ul:a}uthor}({it:string}) {bf:{ul:c}ontact}({it:string}) {bf:{ul:u}rl}({it:string}) {bf:{ul:auto}prompt} {bf:{ul:git}hub} ]
+{p_end}
 
-{col 5}{it:options}{col 25}Description
-{space 4}{hline 33}
-{col 5}{ul:adf}older({it:string}){col 25}Location where package folder will be created
-{col 5}{ul:n}ame({it:string}){col 25}Name of package
-{col 5}{ul:d}escription({it:string}){col 25}Description of package
-{col 5}{ul:a}uthor({it:string}){col 25}Author or authors
-{col 5}{ul:c}ontact({it:string}){col 25}Contact information
-{col 5}{ul:u}rl({it:string}){col 25}URl (for example to repo hosting the package)
-{col 5}{ul:autocon}firm{col 25}Suppress the prompt asking user to confirm package creation
-{space 4}{hline 33}
+{synoptset 19}{...}
+{synopthdr:options}
+{synoptline}
+{synopt: {bf:{ul:adf}older}({it:string})}Location where package folder will be created{p_end}
+{synopt: {bf:{ul:n}ame}({it:string})}Name of package{p_end}
+{synopt: {bf:{ul:d}escription}({it:string})}Description of package{p_end}
+{synopt: {bf:{ul:a}uthor}({it:string})}Author or authors{p_end}
+{synopt: {bf:{ul:c}ontact}({it:string})}Contact information{p_end}
+{synopt: {bf:{ul:u}rl}({it:string})}URl (for example to repo hosting the package){p_end}
+{synopt: {bf:{ul:auto}prompt}}Suppress the prompt for missing non-required input{p_end}
+{synopt: {bf:{ul:git}hub}}Add GitHub template files without prompting{p_end}
+{synoptline}
 
 {title:Description}
 
-{p 4 4 2}
-This command creates the initial folder template needed to write and document Stata command packages in the adodown workflow.
+{pstd}This command creates the initial folder template needed to write and document Stata command packages in the {inp:adodown} workflow.
+{p_end}
 
-{p 4 4 2}
-This workflow makes it easier to create Stata command and packages both ready for distribution on SSC and from a GitHub repository. This workflow also makes writing both web-documentation and helpfiles easier. The helpfiles are written in markdown files that are then used both to render Stata helpfile in {c 96}.sthlp{c 96}-format and to render web documentation that can, for example, be hosted in a GitHub Page.
+{pstd}This workflow makes it easier to create Stata command and packages both ready for distribution on SSC and from a GitHub repository. This workflow also makes writing both web-documentation and helpfiles easier. The helpfiles are written in markdown files that are then used both to render Stata helpfile in {inp:.sthlp}-format and to render web documentation that can, for example, be hosted in a GitHub Page.
+{p_end}
 
 {title:Options}
 
-{p 4 4 2}
-{ul:adf}older({it:string}) is used to indicate the location where package folder will be created. This folder can for example be a newly created GitHub repository cloned to the local computer.
+{pstd}{bf:{ul:adf}older}({it:string}) is used to indicate the location where package folder will be created. This folder can for example be a newly created GitHub repository cloned to the local computer.
+{p_end}
 
-{p 4 4 2}
-{ul:n}ame({it:string}) specifies the name of the package that will be created. This is the name that would then be used in {c 96}ssc install <name>{c 96} or {c 96}net install <name>{c 96}. A command with the same name will be created and added to the package. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{pstd}{bf:{ul:n}ame}({it:string}) specifies the name of the package that will be created. This is the name that would then be used in {inp:ssc install <name>} or {inp:net install <name>}. A command with the same name will be created and added to the package. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{p_end}
 
-{p 4 4 2}
-{ul:d}escription({it:string}) specifies the description of the package. This is the description paragraph that will displayed when using {c 96}ssc describe <name>{c 96} or {c 96}net describe <name>{c 96}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{pstd}{bf:{ul:d}escription}({it:string}) specifies the description of the package. This is the description paragraph that will displayed when using {inp:ssc describe <name>} or {inp:net describe <name>}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{p_end}
 
-{p 4 4 2}
-{ul:a}uthor({it:string}) specifies the name of the author or authors of this package. This information will be included when using {c 96}ssc describe <name>{c 96} or {c 96}net describe <name>{c 96}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{pstd}{bf:{ul:a}uthor}({it:string}) specifies the name of the author or authors of this package. This information will be included when using {inp:ssc describe <name>} or {inp:net describe <name>}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{p_end}
 
-{p 4 4 2}
-{ul:c}ontact({it:string}) specifies the contact information where a users of this package can ask for support. This information will be included when using {c 96}ssc describe <name>{c 96} or {c 96}net describe <name>{c 96}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{pstd}{bf:{ul:c}ontact}({it:string}) specifies the contact information where a users of this package can ask for support. This information will be included when using {inp:ssc describe <name>} or {inp:net describe <name>}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{p_end}
 
-{p 4 4 2}
-{ul:u}rl({it:string}) specifies a website for where this code is hosted. This should not be where the web-documentation generated in the adodown is hosted, but where the source code is hosted. The web-documentation will include a link pointing to the URL. If using GitHub, then the intended URL should be on this format: https://github.com/lsms-worldbank/adodown. This information will be included when using {c 96}ssc describe <name>{c 96} or {c 96}net describe <name>{c 96}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{pstd}{bf:{ul:u}rl}({it:string}) specifies a website for where this code is hosted. This should not be where the web-documentation generated in the adodown is hosted, but where the source code is hosted. The web-documentation will include a link pointing to the URL. If using GitHub, then the intended URL should be on this format: https://github.com/lsms-worldbank/adodown. This information will be included when using {inp:ssc describe <name>} or {inp:net describe <name>}. While this option is optional, this package meta data is required. So if this option is not used, the user will be prompted to enter the name interactively.
+{p_end}
+
+{pstd}{bf:{ul:auto}prompt} suppresses the prompt for missing non-required input, such as package description or author. If this options is used, the command will assume that GitHub templates should not be used. When this option is used, the command will still prompt the user for the package name unless that is provided in {inp:name()} as that information is required.
+{p_end}
+
+{pstd}{bf:{ul:git}hub} makes the command add template files useful if the package is stored in a GitHub repository. The two files that are added are a .gitignore file and a GitHub Actions template. The .gitignore is tailored to adodown styled packages such that only required files are pushed to the repository. This template may be modified if preferred or needed. The Github Actions template includes instructions for an automated workflow to generate web based documentation. Read more about this workflow and how to enable it in your repository here. TODO: Add link to vignette when live.
+{p_end}
 
 {title:Examples}
 
-{p 4 4 2}
-This example creates a package folder for a package named {c 96}my_package{c 96} in the location that the local {c 96}myfolder{c 96} points to.
+{pstd}This example creates a package folder for a package named {inp:my_package} in the location that the local {inp:myfolder} points to.
+{p_end}
 
-{c 96}{c 96}{c 96} 
-{break}    * point a local to the folder where the package will be created
-local myfolder "path/to/folder"
+{input}{space 8}* point a local to the folder where the package will be created
+{space 8}local myfolder "path/to/folder"
 
-{break}    * Package meta info
-local pkg "my_package"
-local aut "John Doe"
-local des "This packages does amazing thing A, B and C."
-local url "https://github.com/lsms-worldbank/adodown"
-local con "jdoe@worldbank.org"
+{space 8}* Package meta info
+{space 8}local pkg "my_package"
+{space 8}local aut "John Doe"
+{space 8}local des "This packages does amazing thing A, B and C."
+{space 8}local url "https://github.com/lsms-worldbank/adodown"
+{space 8}local con "jdoe@worldbank.org"
 
-{break}    * Set up adodown-styled package folder
-ad_setup, adfolder("{c 96}myfolder{c 39}") autoconfirm    ///
-     name("`pkg'") author("`aut'") desc("`des'") ///
-     url("`url'") contact("`con'")
-{c 96}{c 96}{c 96} 
-
+{space 8}* Set up adodown-styled package folder
+{space 8}ad_setup, adfolder("") autoprompt    ///
+{space 8}     name("") author("") desc("") ///
+{space 8}     url("") contact("")
+{text}
 {title:Feedback, bug reports and contributions}
 
-{p 4 4 2}
-Please use the  {browse "https://github.com/lsms-worldbank/adodown/issues":issues feature} on the GitHub repository for the adodown package to communicate any feedback, report bugs, or to make feature requests.
+{pstd}Please use the {browse "https://github.com/lsms-worldbank/adodown/issues":issues feature} on the GitHub repository for the {inp:adodown} package to communicate any feedback, report bugs, or to make feature requests.
+{p_end}
 
 {title:Authors}
 
-{break}    * Author: John Doe
-{break}    * Support: jdoe@worldbank.org
-
-
+{pstd}* Author: John Doe
+* Support: jdoe@worldbank.org
+{p_end}

--- a/src/sthlp/ad_sthlp.sthlp
+++ b/src/sthlp/ad_sthlp.sthlp
@@ -1,86 +1,89 @@
 {smcl}
+{* 01 Jan 1960}{...}
+{hline}
+{pstd}help file for {hi:ad_sthlp}{p_end}
+{hline}
+
 {title:Title}
 
-{p 4 4 2}
-{bf:ad_sthlp} - Renders sthlp-files from mdhlp-files in the adodown workflow.
+{phang}{bf:ad_sthlp} - Renders sthlp-files from mdhlp-files in the {inp:adodown} workflow.
+{p_end}
 
 {title:Syntax}
 
-{p 4 4 2}
-{bf:ad_sthlp} , {ul:adf}older({it:string})
+{phang}{bf:ad_sthlp} , {bf:{ul:adf}older}({it:string})
+{p_end}
 
-{col 5}{it:options}{col 23}Description
-{space 4}{hline 31}
-{col 5}{ul:adf}older({it:string}){col 23}Location where package folder already exists
-{space 4}{hline 31}
+{synoptset 16}{...}
+{synopthdr:options}
+{synoptline}
+{synopt: {bf:{ul:adf}older}({it:string})}Location where package folder already exists{p_end}
+{synoptline}
 
 {title:Description}
 
-{p 4 4 2}
-This command renders Stata helpfiles in the {c 96}.sthlp{c 96} format written in the mdhlp-files written in markdown. The sthlp-files are then intended to be included instead of the mdhlp-files when distributing the command using either either {c 96}ssc install{c 96} or {c 96}net install{c 96}.
+{pstd}This command renders Stata helpfiles in the {inp:.sthlp} format
+written in the mdhlp-files written in markdown.
+The sthlp-files are then intended to be included instead
+of the mdhlp-files when distributing the command using
+either {inp:ssc install} or {inp:net install}.
+{p_end}
 
-{p 4 4 2}
-In the adodown workflow the mdhlp-files are expected to be stored in a folder {c 96}mdhlp{c 96} in the folder that {ul:adf}older({it:string}) points to, and the sthlp-files are expted to be written to a folder {c 96}sthlp{c 96} in the same location. If the package folder was set up using {c 96}ad_setup{c 96} and the commands were added to the package folder using {c 96}ad_command{c 96}, then this is already the case.
+{pstd}In the {inp:adodown} workflow the mdhlp-files are expected to be stored in a folder {inp:mdhlp} in the folder that {bf:{ul:adf}older}({it:string}) points to, and the sthlp-files are expected to be written to a folder {inp:sthlp} in the same location. If the package folder was set up using {inp:ad_setup} and the commands were added to the package folder using {inp:ad_command}, then this is already the case.
+{p_end}
 
 {title:Options}
 
-{p 4 4 2}
-{ul:adf}older({it:string}) is used to indicate the location of where the adodown-styled package folder already exist.
+{pstd}{bf:{ul:adf}older}({it:string}) is used to indicate the location of where the adodown-styled package folder already exist.
+{p_end}
 
 {title:Examples}
 
-{p 4 4 2}
-{bf:Example 1}
+{dlgtab:Example 1}
 
-{p 4 4 2}
-This example assumes that there is already a adodown-styled package folder at the location the local {c 96}myfolder{c 96} is pointing to, and that some commands have already been created. Any mdhlp-files in the {c 96}mdhlp{c 96} folder in the folder {c 96}myfolder{c 96} is pointing to will be rendered to Stata helpfile format and saved in the {c 96}sthlp{c 96} folder.
+{pstd}This example assumes that there is already a adodown-styled package folder at the location the local {inp:myfolder} is pointing to, and that some commands have already been created. Any mdhlp-files in the {inp:mdhlp} folder in the folder {inp:myfolder} is pointing to will be rendered to Stata helpfile format and saved in the {inp:sthlp} folder.
+{p_end}
 
-{c 96}{c 96}{c 96} 
-{break}    * point a local to the folder where the package will be created
-local myfolder "path/to/folder"
+{input}{space 8}* point a local to the folder where the package will be created
+{space 8}local myfolder "path/to/folder"
 
-{break}    * Render the Stata helpfiles
-ad_sthlp, adf("{c 96}myfolder{c 39}")
-{c 96}{c 96}{c 96} 
+{space 8}* Render the Stata helpfiles
+{space 8}ad_sthlp, adf("")
+{text}
+{dlgtab:Example 2}
 
-{p 4 4 2}
-{bf:Example 2}
+{pstd}This example includes the steps for how to create the adodown-styled package folder in the location the local {inp:myfolder} is pointing to, creating some commands and then render the template mdhlp-files to Stata helpfiles.
+{p_end}
 
-{p 4 4 2}
-This example includes the steps for how to create the adodown-styled package folder in the location the local {c 96}myfolder{c 96} is pointing to, creating some commands and then render the template mdhlp-files to Stata helpfiles.
+{input}{space 8}* point a local to the folder where the package will be created
+{space 8}local myfolder "path/to/folder"
 
-{c 96}{c 96}{c 96} 
-{break}    * point a local to the folder where the package will be created
-local myfolder "path/to/folder"
+{space 8}* Package meta info
+{space 8}local pkg "my_package"
+{space 8}local aut "John Doe"
+{space 8}local des "This packages does amazing thing A, B and C."
+{space 8}local url "https://github.com/lsms-worldbank/adodown"
+{space 8}local con "jdoe@worldbank.org"
 
-{break}    * Package meta info
-local pkg "my_package"
-local aut "John Doe"
-local des "This packages does amazing thing A, B and C."
-local url "https://github.com/lsms-worldbank/adodown"
-local con "jdoe@worldbank.org"
+{space 8}* Set up adodown-styled package folder
+{space 8}ad_setup, adfolder("") autoconfirm    ///
+{space 8}     name("") author("") desc("") ///
+{space 8}     url("") contact("")
 
-{break}    * Set up adodown-styled package folder
-ad_setup, adfolder("{c 96}myfolder{c 39}") autoconfirm    ///
-     name("`pkg'") author("`aut'") desc("`des'") ///
-     url("`url'") contact("`con'")
+{space 8}* Add command mycmd to the package folder
+{space 8}ad_command create mycmd1, adf("") pkg("")
+{space 8}ad_command create mycmd2, adf("") pkg("")
 
-{break}    * Add command mycmd to the package folder
-ad_command create mycmd1, adf("{c 96}myfolder{c 39}") pkg("{c 96}pkg{c 39}")
-ad_command create mycmd2, adf("{c 96}myfolder{c 39}") pkg("{c 96}pkg{c 39}")
-
-{break}    * Render the Stata helpfiles
-ad_sthlp, adf("{c 96}myfolder{c 39}")
-{c 96}{c 96}{c 96} 
-
+{space 8}* Render the Stata helpfiles
+{space 8}ad_sthlp, adf("")
+{text}
 {title:Feedback, bug reports and contributions}
 
-{p 4 4 2}
-Please use the  {browse "https://github.com/lsms-worldbank/adodown/issues":issues feature} on the GitHub repository for the adodown package to communicate any feedback, report bugs, or to make feature requests.
+{pstd}Please use the {browse "https://github.com/lsms-worldbank/adodown/issues":issues feature} on the GitHub repository for the {inp:adodown} package to communicate any feedback, report bugs, or to make feature requests.
+{p_end}
 
 {title:Authors}
 
-{break}    * Author: John Doe
-{break}    * Support: jdoe@worldbank.org
-
-
+{pstd}Author: John Doe
+Support: jdoe@worldbank.org
+{p_end}

--- a/src/vignettes/mdhlp-syntax.md
+++ b/src/vignettes/mdhlp-syntax.md
@@ -25,13 +25,17 @@ the SMCL format that is used in Stata helpfiles.
 
 | Markdown syntax | Description | SMCL syntax | Comment |
 | ---  | --- | --- | --------- |
-| `#`  | Header level 1 | Using `{title}` tag  | |
-| `##` | Header level 2 | Using `{dlgtab}` tag  | No formatting applied if using  more `#`. As in `###`, `####` etc. |
+|   | Paragraph | Using `{pstd}`/`{p_end}` tags  | In markdown a paragraph is not defined by a character. Instead, a paragraph is defined as text between empty lines with no other formatting (part from inline formatting) |
+| `#`  | Header level 1 | Using `{title:}` tag  | |
+| `##` | Header level 2 | Using `{dlgtab:}` tag  | No formatting applied if using  more `#`. As in `###`, `####` etc. |
 | `__ __` | Inline bold font | Using `{bf:}` tag | Ignored within code formatting |
 | `** **` | Inline underlined font | Using `{ul:}` tag  | Ignored unless used for text already in bold font |
 | `_ _` | Inline italic font | Using `{it:}` tag | Ignored in bold font |
 | `` ` ` `` | Inline code font | Using `{inp:}` tag | All other inline formatting is ignored within the `` ` `` tags |
-| ```` ``` ```` / ```` ``` ```` | Multiline code block | Using `{input}`/`{text}` tag | Ignores all formatting within the ```` ``` ```` tags  |
+| ```` ``` ```` / ```` ``` ```` | Multiline code block | Using `{input}`/`{text}` tags | Ignores all formatting within the ```` ``` ```` tags  |
+| `\|   \|   \|` / `\|--\|--\|` / `\|   \|   \|`  | Syntax tables | Using `{synopt}` table syntax | Only works for a two-column table in the _Syntax_ section. |
+
+
 
 #### Paragraphs
 
@@ -119,7 +123,7 @@ format syntax of command names and command option names.
 
 | Example      | Description  |  
 | ---          | ---          |  
-| `__ad_sthlp__` | Command named `ad_sthlp`. Do not use underline in command names as abbreviations are not allowed in names of community written commands. | 
+| `__ad_sthlp__` | Command named `ad_sthlp`. Do not use underline in command names as abbreviations are not allowed in names of community written commands. |
 | `__option__` | Option named `option`. No parameter is allowed. No abbreviation is allowed. |
 | `__**opt**ion__` | Option named `option`. No parameter is allowed. The option named is allowed to abbreviate to `opt`. |
 | `__option__(_string_)` | Option named `option`. A string parameter is expected. No abbreviation is allowed. |
@@ -153,3 +157,19 @@ The initial ```` ``` ```` will be replaced with the `{input}` tag,
 and the ending ```` ``` ```` will be replaced with `{text}`.
 The text in-between is indented 8 blank spaces
 (twice the indent for `{pstd}`).
+
+#### Syntax option tables
+
+The only supported table is the syntax option table in the _Syntax_ section.
+This is a table that list all the options in the first column and
+provide a short description in the second column.
+The table may only be exactly two columns wide.
+When rendered into a Stata helpfile the column titles will be
+"_options_" and "Description" which is the Stata defaults.
+Only "_options_" will be italicized.
+
+Tables in any other section than the _Syntax_ section
+will be ignored in the current version of `ad_sthlp`.
+Until support for tables in other sections are implemented,
+the recommendation is to use vignette articles to document anything
+best described in a table.

--- a/src/vignettes/mdhlp-syntax.md
+++ b/src/vignettes/mdhlp-syntax.md
@@ -1,0 +1,155 @@
+# mdhlp syntax documentation
+
+This article provides documentation for how to write helpfiles
+in an adodown styled Stata package using mdhlp files.
+The mdhlp files are used as source both when building web based documentation
+and when rendering Stata helpfiles in `.sthlp` format.
+
+## Start with template
+
+We recommend that you use a template and do not start with an empty file.
+Easiest is to use `ad_command` when starting a new command to create both
+the `.ado` in the ado-folder for the code of the command,
+and the `.md` in the mdhlp-folder for the documentation.
+If you for any reason can not, or do not want, to use `ad_command`,
+but still want use this workflow,
+then you can manually download the template from
+[here](https://github.com/lsms-worldbank/adodown/blob/main/src/ado/templates/ad-cmd-command.md).
+
+## Syntax supported when rendering .sthlp files
+
+This is how `ad_sthlp` will render markdown syntax to
+the SMCL format that is used in Stata helpfiles.
+
+#### Overview
+
+| Markdown syntax | Description | SMCL syntax | Comment |
+| ---  | --- | --- | --------- |
+| `#`  | Header level 1 | Using `{title}` tag  | |
+| `##` | Header level 2 | Using `{dlgtab}` tag  | No formatting applied if using  more `#`. As in `###`, `####` etc. |
+| `__ __` | Inline bold font | Using `{bf:}` tag | Ignored within code formatting |
+| `** **` | Inline underlined font | Using `{ul:}` tag  | Ignored unless used for text already in bold font |
+| `_ _` | Inline italic font | Using `{it:}` tag | Ignored in bold font |
+| `` ` ` `` | Inline code font | Using `{inp:}` tag | All other inline formatting is ignored within the `` ` `` tags |
+| ```` ``` ```` / ```` ``` ```` | Multiline code block | Using `{input}`/`{text}` tag | Ignores all formatting within the ```` ``` ```` tags  |
+
+#### Paragraphs
+
+Text that are not tables, headers or code blocks that follows
+an empty line will be interpreted as a paragraph and the `{pstd}` will be used.
+
+The `{pstd}` tag will be added in the beginning of the first line of text,
+and `{p_end}` will added on it's own line
+before the first subsequent empty line.
+This means that lines of regular text separated by a line break will
+still be considered the same paragraph unless there also is a empty line.
+
+#### Headers
+
+`ad_sthlp` has support for two header levels corresponding to
+markdowns header levels `#` for level 1 and `##` for level 2.
+Level 1 headers are formatted using the `{title}` tag
+when rendered to Stata helpfiles,
+and level 2 headers are formatted using the `{dlgtb}` tag.
+
+There is no established convention in the Stata community
+that `{title}` and `{dlgtb}` have a
+level 1 and 2 relation between each other.
+This is simply a subjective implementation of `ad_sthlp`.
+
+###### Level 1 - Title
+Any line that starts with `#` will be treated as a level 1 heading and
+rendered as a title using the `{title}` tag.
+Everything that follows `#` will be used as the title text.
+Adding other types of formatting to the title text might work,
+but is not supported, and therefore not recommended.
+
+###### Level 2 - Dialogue Tab
+Any line that starts with `##` will be treated as a level 2 heading and
+rendered as a dialogue tab using the `{dlgtab}` tag.
+Everything that follows `##` will be used as the dialogue tab text.
+Adding other types of formatting to the dialogue box text might work,
+but is not supported, and therefore not recommended.
+
+#### Inline text formatting
+
+######  Bold inline formatting
+
+Text between `__` (two `_` underscores) tags, as in `__bold text__`,
+is formatted as `{bf:bold text}` when rendered to Stata helpfiles.
+
+###### Italic formatting
+
+Text between `_` (a single underscore) tags, as in `_italicized text_`,
+is formatted as `{it:italicized text}` when rendered to Stata helpfiles.
+
+It is not possible to italicize a word with `_`,
+as `_` in an italicized word will always be interpreted as
+the end of italic formatting.
+
+It is not possible to italicize bold font text.
+This is to make it possible to express as command name like
+`ad_sthlp` in bold font.
+`_` is therefore ignored in bold font.
+
+###### Underlined inline formatting
+
+Text between `** **` tags in bold font text, as in `__**underlined text**__`,
+is formatted as `{bf:{ul:italicized text}}` when rendered to Stata helpfiles.
+
+Note that underlined format is ignored unless it is applied
+to text already formatted with bold font.
+This is due to underlined formatting not existing in markdown,
+and markdown is used for the web documentation in the adodown workflow.
+The recommendation is therefore to use underlined formatting sparsely.
+
+However, underlined formatting has one important function in Stata helpfiles.
+It indicates the shortest allowed abbreviations of command and option names.
+Since abbreviations are only allowed for options in community written commands
+we will only focus on underlined formatting for abbreviations in option names.
+
+This is why underlined formatting is only applied to
+text already formatted with bold font,
+as option names are always formatted with bold font.
+
+###### Suggested formatting of command and option names
+
+Here are recommendations on how combine inline formatting to
+format syntax of command names and command option names.
+
+| Example      | Description  |  
+| ---          | ---          |  
+| `__ad_sthlp__` | Command named `ad_sthlp`. Do not use underline in command names as abbreviations are not allowed in names of community written commands. | 
+| `__option__` | Option named `option`. No parameter is allowed. No abbreviation is allowed. |
+| `__**opt**ion__` | Option named `option`. No parameter is allowed. The option named is allowed to abbreviate to `opt`. |
+| `__option__(_string_)` | Option named `option`. A string parameter is expected. No abbreviation is allowed. |
+| `__**opt**ion__(_string_)` | Option named `option`. A string parameter is expected. The option named is allowed to abbreviate to `opt`. |
+
+###### Code inline formatting
+
+Any text between two `` ` `` on the same line will be formatted
+using the `{input}` tag.
+You may not split the two `` ` `` across multiple lines.
+If unmatched `` ` `` are found, then a warning will be issued.
+
+It is not possible to show a `` ` `` in an inline comment which
+is needed if showing how a local in Stata is referenced.
+In those cases, use a code block.
+
+All other formatting will be ignored in text that is formatted as a code.
+This means that `cd` in `ab_cd_ef` will not be italicized.
+The `_` signs will be kept and formatted as code.
+
+#### Code blocks formatting
+
+Any text between lines that starts with ```` ``` ````
+(commonly referred to as a code block)
+will be formatted using the `{input}` tag.
+Any text following on the same line as ```` ``` ```` will
+be ignored when rendering the Stata help files.
+Code blocks are suitable for longer examples of code.
+
+The initial ```` ``` ```` will be replaced with the `{input}` tag,
+and the ending ```` ``` ```` will be replaced with `{text}`.
+The text in-between is indented 8 blank spaces
+(twice the indent for `{pstd}`).

--- a/src/vignettes/mdhlp-syntax.md
+++ b/src/vignettes/mdhlp-syntax.md
@@ -33,9 +33,8 @@ the SMCL format that is used in Stata helpfiles.
 | `_ _` | Inline italic font | Using `{it:}` tag | Ignored in bold font |
 | `` ` ` `` | Inline code font | Using `{inp:}` tag | All other inline formatting is ignored within the `` ` `` tags |
 | ```` ``` ```` / ```` ``` ```` | Multiline code block | Using `{input}`/`{text}` tags | Ignores all formatting within the ```` ``` ```` tags  |
+| ` [ ]( ) ` | Hyperlinks | Using `{browse link:text}` tags | May not be combined with other types of formatting |
 | `\|   \|   \|` / `\|--\|--\|` / `\|   \|   \|`  | Syntax tables | Using `{synopt}` table syntax | Only works for a two-column table in the _Syntax_ section. |
-
-
 
 #### Paragraphs
 
@@ -157,6 +156,16 @@ The initial ```` ``` ```` will be replaced with the `{input}` tag,
 and the ending ```` ``` ```` will be replaced with `{text}`.
 The text in-between is indented 8 blank spaces
 (twice the indent for `{pstd}`).
+
+#### Hyperlinks
+
+Markdown links on the format
+`[adodown](https://github.com/lsms-worldbank/adodown)`
+will be converted to SMCL links on the format
+`{browse "https://github.com/lsms-worldbank/adodown":adodown}`.
+Only links to internet URLs are supported.
+Creating hyperlinks to resources installed in the local Stata installation,
+for example `{help : generate}`, are currently not supported.
 
 #### Syntax option tables
 

--- a/src/vignettes/mdhlp-syntax.md
+++ b/src/vignettes/mdhlp-syntax.md
@@ -35,6 +35,7 @@ the SMCL format that is used in Stata helpfiles.
 | ```` ``` ```` / ```` ``` ```` | Multiline code block | Using `{input}`/`{text}` tags | Ignores all formatting within the ```` ``` ```` tags  |
 | ` [ ]( ) ` | Hyperlinks | Using `{browse link:text}` tags | May not be combined with other types of formatting |
 | `\|   \|   \|` / `\|--\|--\|` / `\|   \|   \|`  | Syntax tables | Using `{synopt}` table syntax | Only works for a two-column table in the _Syntax_ section |
+| `<!--` / `-->` | Comments | Commented lines are ignored | Supports both multi and single line comments  |
 
 #### Paragraphs
 
@@ -193,3 +194,22 @@ will be ignored in the current version of `ad_sthlp`.
 Until support for tables in other sections are implemented,
 the recommendation is to use vignette articles to document anything
 best described in a table.
+
+#### Comments
+
+Any line that starts with `<!--` will be treated as a comment and be ignored
+when converting to `.sthlp` format.
+A comment ends with `-->`.
+If `<!--` and `-->` are on multiple lines, then both those lines,
+as well as any lines in-between those lines, will be treated as comments.
+
+Anything on the same line as `-->` will be treated as a comment
+even if it comes after `-->`.
+A line with any text before `<!--` will not be treated as a comment
+and a warning will be thrown.
+Due to these two behaviors it is not possible to do an inline comment
+where only part of a line is a comment.
+Hence, the line `Not a comment <!-- comment --> not a comment` will
+be converted verbatim and everything,
+including the `<!--` and `-->` tags,
+will be displayed when viewing the helpfile.

--- a/src/vignettes/mdhlp-syntax.md
+++ b/src/vignettes/mdhlp-syntax.md
@@ -25,7 +25,7 @@ the SMCL format that is used in Stata helpfiles.
 
 | Markdown syntax | Description | SMCL syntax | Comment |
 | ---  | --- | --- | --------- |
-|   | Paragraph | Using `{pstd}`/`{p_end}` tags  | In markdown a paragraph is not defined by a character. Instead, a paragraph is defined as text between empty lines with no other formatting (part from inline formatting) |
+|   | Paragraph | Using `{pstd}`/`{p_end}` tags  | In markdown a paragraph is not defined by a character. Instead, a paragraph is defined as text between empty lines with no other formatting (part from inline formatting). In the _Title_ and _Syntax_ sections the `{phang}` tag is used instead of `{pstd}`. |
 | `#`  | Header level 1 | Using `{title:}` tag  | |
 | `##` | Header level 2 | Using `{dlgtab:}` tag  | No formatting applied if using  more `#`. As in `###`, `####` etc. |
 | `__ __` | Inline bold font | Using `{bf:}` tag | Ignored within code formatting |
@@ -46,6 +46,11 @@ and `{p_end}` will added on it's own line
 before the first subsequent empty line.
 This means that lines of regular text separated by a line break will
 still be considered the same paragraph unless there also is a empty line.
+
+In the _Title_ and _Syntax_ sections the `{phang}` tag
+is used instead of `{pstd}`.
+This is to highlight the command name in the special paragraphs
+typically found in those sections.
 
 #### Headers
 

--- a/src/vignettes/mdhlp-syntax.md
+++ b/src/vignettes/mdhlp-syntax.md
@@ -34,21 +34,21 @@ the SMCL format that is used in Stata helpfiles.
 | `` ` ` `` | Inline code font | Using `{inp:}` tag | All other inline formatting is ignored within the `` ` `` tags |
 | ```` ``` ```` / ```` ``` ```` | Multiline code block | Using `{input}`/`{text}` tags | Ignores all formatting within the ```` ``` ```` tags  |
 | ` [ ]( ) ` | Hyperlinks | Using `{browse link:text}` tags | May not be combined with other types of formatting |
-| `\|   \|   \|` / `\|--\|--\|` / `\|   \|   \|`  | Syntax tables | Using `{synopt}` table syntax | Only works for a two-column table in the _Syntax_ section. |
+| `\|   \|   \|` / `\|--\|--\|` / `\|   \|   \|`  | Syntax tables | Using `{synopt}` table syntax | Only works for a two-column table in the _Syntax_ section |
 
 #### Paragraphs
 
-Text that are not tables, headers or code blocks that follows
+Text that are not formatted as tables, headers or code blocks that follows
 an empty line will be interpreted as a paragraph and the `{pstd}` will be used.
 
 The `{pstd}` tag will be added in the beginning of the first line of text,
 and `{p_end}` will added on it's own line
 before the first subsequent empty line.
-This means that lines of regular text separated by a line break will
-still be considered the same paragraph unless there also is a empty line.
+This means that lines of text only separated by a line breaks will
+still be considered the same paragraph as long as there are no empty lines.
 
-In the _Title_ and _Syntax_ sections the `{phang}` tag
-is used instead of `{pstd}`.
+In the _Title_ and _Syntax_ sections,
+the `{phang}` tag is used instead of `{pstd}`.
 This is to highlight the command name in the special paragraphs
 typically found in those sections.
 
@@ -70,14 +70,14 @@ Any line that starts with `#` will be treated as a level 1 heading and
 rendered as a title using the `{title}` tag.
 Everything that follows `#` will be used as the title text.
 Adding other types of formatting to the title text might work,
-but is not supported, and therefore not recommended.
+but it is not supported, and therefore not recommended.
 
 ###### Level 2 - Dialogue Tab
 Any line that starts with `##` will be treated as a level 2 heading and
 rendered as a dialogue tab using the `{dlgtab}` tag.
 Everything that follows `##` will be used as the dialogue tab text.
 Adding other types of formatting to the dialogue box text might work,
-but is not supported, and therefore not recommended.
+but it is not supported, and therefore not recommended.
 
 #### Inline text formatting
 
@@ -116,9 +116,11 @@ It indicates the shortest allowed abbreviations of command and option names.
 Since abbreviations are only allowed for options in community written commands
 we will only focus on underlined formatting for abbreviations in option names.
 
-This is why underlined formatting is only applied to
-text already formatted with bold font,
-as option names are always formatted with bold font.
+Option names are in bold font,
+and underline font should therefore only be used on text in bold font.
+This reduces the risk of relying too much on underlined formatting
+when writing Stata helpfiles
+and then realizing underlining is not supported in web documentation.
 
 ###### Suggested formatting of command and option names
 
@@ -140,9 +142,13 @@ using the `{input}` tag.
 You may not split the two `` ` `` across multiple lines.
 If unmatched `` ` `` are found, then a warning will be issued.
 
-It is not possible to show a `` ` `` in an inline comment which
-is needed if showing how a local in Stata is referenced.
-In those cases, use a code block.
+It is not possible to show a backtick `` ` `` in an inline comment.
+For example when trying to show a local referenced as in
+`` open `folder'/myfile.dta ``.
+The `` ` `` in the inline formatting will always be
+interpreted as the end of the inline code formatting
+when converted to Stata help files.
+It is still possible to show the backtick `` ` `` in code blocks (see below).
 
 All other formatting will be ignored in text that is formatted as a code.
 This means that `cd` in `ab_cd_ef` will not be italicized.
@@ -154,7 +160,7 @@ Any text between lines that starts with ```` ``` ````
 (commonly referred to as a code block)
 will be formatted using the `{input}` tag.
 Any text following on the same line as ```` ``` ```` will
-be ignored when rendering the Stata help files.
+be ignored when converting to Stata help files.
 Code blocks are suitable for longer examples of code.
 
 The initial ```` ``` ```` will be replaced with the `{input}` tag,


### PR DESCRIPTION
This PR includes an update to `ad_sthlp` that includes a custom `mdhlp` to `sthlp` conversion. 

This makes it possible to not have to rely on the external tool `markdoc`. `markdoc` is great but dependencies does not work great in Stata. And with our own conversion code we can make this conversion fit in the adodown ecosystem even better.