### PR TITLE
Update R pkg's path and name in GitHub Action

### DIFF
--- a/.github/workflows/build_adodown_site.yaml
+++ b/.github/workflows/build_adodown_site.yaml
@@ -49,7 +49,7 @@ jobs:
         run: install.packages("devtools")
         shell: Rscript {0}
 
-      - name: Install adodown
+      - name: Install adodownr
         run: devtools::install_github("lsms-worldbank/adodownr")
         shell: Rscript {0}
 

--- a/.github/workflows/build_adodown_site.yaml
+++ b/.github/workflows/build_adodown_site.yaml
@@ -50,7 +50,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Install adodown
-        run: devtools::install_github("arthur-shaw/adodown")
+        run: devtools::install_github("lsms-worldbank/adodownr")
         shell: Rscript {0}
 
       - name: Install here
@@ -58,7 +58,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Build site
-        run: adodown::build_site(pkg_dir = here::here(), site_dir = here::here())
+        run: adodownr::build_site(pkg_dir = here::here(), site_dir = here::here())
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages

--- a/.github/workflows/build_adodown_site.yaml
+++ b/.github/workflows/build_adodown_site.yaml
@@ -1,8 +1,6 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
 
 name: Build Site
 


### PR DESCRIPTION
This PR:

- updates the package name from `adodown` to `adodownr`
- updates the GitHub path for the package
- removes the PR trigger for the job

Note: I successfully tested this new GHA script [here](https://github.com/arthur-shaw/test_gha/actions/runs/7479706786).