### PR TITLE
Better manage site state so GHA deploys it

### DIFF
--- a/.github/workflows/build_adodown_site.yaml
+++ b/.github/workflows/build_adodown_site.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Deploy to GitHub pages
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
-          clean: false
+          clean: true
           folder: docs
           branch: gh-pages
           target-folder: docs

--- a/.github/workflows/build_adodown_site.yaml
+++ b/.github/workflows/build_adodown_site.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           version: 1.0.37
 
-      - name: Install dependencies
+      - name: Install Linux system dependencies
         run: |
           sudo apt-get install -y make
           sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/build_adodown_site.yaml
+++ b/.github/workflows/build_adodown_site.yaml
@@ -58,7 +58,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Build site
-        run: adodownr::build_site(pkg_dir = here::here(), site_dir = here::here())
+        run: adodownr::build_site(pkg_dir = here::here(), site_dir = here::here(), rm_old_site_dir = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages

--- a/src/ado/templates/ad-gh-workflows.yaml
+++ b/src/ado/templates/ad-gh-workflows.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Deploy to GitHub pages
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
-          clean: false
+          clean: true
           folder: docs
           branch: gh-pages
           target-folder: docs

--- a/src/ado/templates/ad-gh-workflows.yaml
+++ b/src/ado/templates/ad-gh-workflows.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           version: 1.0.37
 
-      - name: Install dependencies
+      - name: Install Linux system dependencies
         run: |
           sudo apt-get install -y make
           sudo apt-get install -y libcurl4-openssl-dev

--- a/src/ado/templates/ad-gh-workflows.yaml
+++ b/src/ado/templates/ad-gh-workflows.yaml
@@ -58,7 +58,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Build site
-        run: adodownr::build_site(pkg_dir = here::here(), site_dir = here::here())
+        run: adodownr::build_site(pkg_dir = here::here(), site_dir = here::here(), rm_old_site_dir = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages


### PR DESCRIPTION
While adodownr has been updated to have better defaults and handle issues, the GHA needs to be updated too, in a few ways:

1. Ensure adodownr's new default not to delete site is explictly used
2. Have GitHub Pages Deploy action prune files that no longer exist on the site

In this PR, make edits to:

- adodown's own GHA job (i.e., the one that could deploy its adodown(r) site).
- adowdown's template that it instantiates for new pages